### PR TITLE
Don't indent otherwise empty lines.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,12 @@ where
                 self.format.insert_indentation(ind, &mut self.inner)?;
             } else if ind > 0 {
                 self.inner.write_char('\n')?;
+
+                // Don't render the line unless its actually got text on it
+                if line.is_empty() {
+                    continue;
+                }
+
                 self.format.insert_indentation(ind, &mut self.inner)?;
             }
 
@@ -287,6 +293,17 @@ mod tests {
             input
         )
         .unwrap();
+
+        assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn trailing_newlines() {
+        let input = "verify\nthis\n";
+        let expected = "  verify\n  this\n";
+        let output = &mut String::new();
+
+        write!(indented(output).with_str("  "), "{}", input).unwrap();
 
         assert_eq!(expected, output);
     }


### PR DESCRIPTION
Hello 👋

Thanks for writing this crate - nearly wrote something to do it myself,
but this covers my use case pretty well.  Found a small issue though 
which this PR hopes to fix.

I've been trying to use `indenter` to output some generated rust code.  
The code I'm working with looks roughly like this:

```rust
writeln!(output, "struct SomeData {{");
writeln!(indented(output).with_str("   "), "{}", some_field);
writeln!(output, "}}");
```

Since indenter is splitting on `\n` and inserting indentation for each
`\n` this ends up leaving some trailing indentation on the middle
writeln, giving me this output:

```rust
struct SomeData {
    some_field: i32
    }
```

Seems like it's easy to fix - just don't add indentation to otherwise 
empty lines.  Not 100% sure if this works for all use cases though...?