### PR TITLE
Don't indent otherwise empty lines.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ where
     T: fmt::Write + ?Sized,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        for (ind, mut line) in s.split('\n').enumerate() {
+        for (ind, line) in s.split('\n').enumerate() {
             if ind > 0 {
                 self.inner.write_char('\n')?;
                 self.needs_indent = true;
@@ -157,7 +157,6 @@ where
 
             if self.needs_indent {
                 // trim line to ensure it lines up with the number nicely
-                line = line.trim_start();
                 // Don't render the line unless its actually got text on it
                 if line.is_empty() {
                     continue;
@@ -307,7 +306,7 @@ mod tests {
     #[test]
     fn several_interpolations() {
         let input = "verify\nthis\n";
-        let expected = "  verify\n  this\n  and verify\n  this\n";
+        let expected = "  verify\n  this\n   and verify\n  this\n";
         let output = &mut String::new();
 
         write!(indented(output).with_str("  "), "{} and {}", input, input).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,6 @@ where
             }
 
             if self.needs_indent {
-                // trim line to ensure it lines up with the number nicely
                 // Don't render the line unless its actually got text on it
                 if line.is_empty() {
                     continue;


### PR DESCRIPTION
Following up from our chat in #7: 

I'm trying to use `indenter` to output some generated rust code.  The
code I'm working with looks roughly like this:

```rust
writeln!(output, "struct SomeData {{");
write!(indented(output).with_str("   "), "{}", some_field);
writeln!(output, "}}");
```

(Where the Display impl for `some_field` ends with a trailing new line)

Since indenter is splitting on `\n` and inserting indentation for each
`\n` this ends up leaving some trailing indentation on the middle
writeln, giving me this output:

```rust
struct SomeData {
    some_field: i32
    }
```

This commit has a fix for that - it doesn't bother adding indentation to
lines which are otherwise empty.  Uses a `needs_indent` variable to
track this across calls to `write_str` - similar to the `started`
variable before but for every line.