### PR TITLE
Add CodeFormatter to help dedenting and identing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ A formatter wrapper that indents the text, designed for error display impls
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+std = []
+
 [dependencies]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -11,11 +11,8 @@
 [docs-badge]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-url]: https://docs.rs/indenter
 
-A wrapper for the `fmt::Write` objects that efficiently appends indentation
-after every newline.
-
-This type is intended primarily for writing error reporters that gracefully
-format error messages that span multiple lines.
+A few wrappers for the `fmt::Write` objects that efficiently appends and remove
+common indentation after every newline
 
 ## Setup
 
@@ -26,7 +23,12 @@ Add this to your `Cargo.toml`:
 indenter = "0.2"
 ```
 
-## Example
+## Examples
+
+## Indentation only
+
+This type is intended primarily for writing error reporters that gracefully
+format error messages that span multiple lines.
 
 ```rust
 use std::error::Error;
@@ -51,6 +53,46 @@ impl fmt::Debug for ErrorReporter<'_> {
         Ok(())
     }
 }
+```
+
+## "Dedenting" (removing common leading indendation)
+
+This type is intended primarily for formatting source code. For example, when
+generating code.
+
+```rust
+use std::error::Error;
+use core::fmt::{self, Write};
+use indenter::CodeFormatter;
+
+let mut output = String::new();
+let mut f = CodeFormatter::new(&mut output, "    ");
+
+write!(
+    f,
+    r#"
+    Hello
+        World
+    "#,
+);
+
+assert_eq!(output, "Hello\n    World\n");
+
+let mut output = String::new();
+let mut f = CodeFormatter::new(&mut output, "    ");
+
+// it can also indent...
+f.indent(2);
+
+write!(
+    f,
+    r#"
+    Hello
+        World
+    "#,
+);
+
+assert_eq!(output, "        Hello\n            World\n");
 ```
 
 #### License

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ impl fmt::Debug for ErrorReporter<'_> {
 This type is intended primarily for formatting source code. For example, when
 generating code.
 
+This type requires the feature `std`.
+
 ```rust
 use std::error::Error;
 use core::fmt::{self, Write};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-//! A wrapper for the `fmt::Write` objects that efficiently appends indentation after every newline
+//! A few wrappers for the `fmt::Write` objects that efficiently appends and remove
+//! common indentation after every newline
 //!
 //! # Setup
 //!
@@ -10,6 +11,8 @@
 //! ```
 //!
 //! # Example
+//!
+//! ## Indentation only
 //!
 //! ```rust
 //! use std::error::Error;
@@ -34,6 +37,49 @@
 //!         Ok(())
 //!     }
 //! }
+//! ```
+//!
+//! ## "Dedenting" (removing common leading indendation)
+//!
+//! ```rust
+//! # #[cfg(feature = "std")]
+//! # fn main() {
+//! use std::error::Error;
+//! use core::fmt::{self, Write};
+//! use indenter::CodeFormatter;
+//!
+//! let mut output = String::new();
+//! let mut f = CodeFormatter::new(&mut output, "    ");
+//!
+//! write!(
+//!     f,
+//!     r#"
+//!     Hello
+//!         World
+//!     "#,
+//! );
+//!
+//! assert_eq!(output, "Hello\n    World\n");
+//!
+//! let mut output = String::new();
+//! let mut f = CodeFormatter::new(&mut output, "    ");
+//!
+//! // it can also indent...
+//! f.indent(2);
+//!
+//! write!(
+//!     f,
+//!     r#"
+//!     Hello
+//!         World
+//!     "#,
+//! );
+//!
+//! assert_eq!(output, "        Hello\n            World\n");
+//! # }
+//! # #[cfg(not(feature = "std"))]
+//! # fn main() {
+//! # }
 //! ```
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc(html_root_url = "https://docs.rs/indenter/0.3.2")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,7 +536,7 @@ mod tests_std {
     fn split_prefix() {
         let mut s = String::new();
         let mut f = CodeFormatter::new(&mut s, "    ");
-        write!(f, "\n").unwrap();
+        writeln!(f).unwrap();
         assert_eq!(s, "\n");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! indenter = "0.2"
 //! ```
 //!
-//! # Example
+//! # Examples
 //!
 //! ## Indentation only
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,4 +477,12 @@ mod tests_std {
         .unwrap();
         assert_eq!(s, "struct Foo;\n            fn foo() {\n            }");
     }
+
+    #[test]
+    fn split_prefix() {
+        let mut s = String::new();
+        let mut f = CodeFormatter::new(&mut s, "    ");
+        write!(f, "\n").unwrap();
+        assert_eq!(s, "\n");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@
 //!
 //! ## Indentation only
 //!
+//! This type is intended primarily for writing error reporters that gracefully
+//! format error messages that span multiple lines.
+//!
 //! ```rust
 //! use std::error::Error;
 //! use core::fmt::{self, Write};
@@ -40,6 +43,11 @@
 //! ```
 //!
 //! ## "Dedenting" (removing common leading indendation)
+//!
+//! This type is intended primarily for formatting source code. For example, when
+//! generating code.
+//!
+//! This type requires the feature `std`.
 //!
 //! ```rust
 //! # #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,9 +200,9 @@ pub struct CodeFormatter<'a, T> {
 #[cfg(feature = "std")]
 impl<'a, T: fmt::Write> fmt::Write for CodeFormatter<'a, T> {
     fn write_str(&mut self, input: &str) -> fmt::Result {
-        let input = match input.strip_prefix('\n') {
-            Some(s) => s,
-            None => return self.f.write_str(input),
+        let input = match input.chars().next() {
+            Some('\n') => &input[1..],
+            _ => return self.f.write_str(input),
         };
 
         let min = input


### PR DESCRIPTION
@yaahc I didn't see at first but `indenter` is `no_std`. I had to add a feature flag `std` which is disabled by default. It should probably become enabled by default in a future major release. (Or you can make the 0.4.0 directly instead)

Before I update the doc :sweat_smile: Are you 100% sure it's okay to move forward with this? I will understand if you just don't want to introduce this in your crate.

Please note that in this current implementation you can release a minor 0.3.3 since it only adds a feature that is off by default.